### PR TITLE
Update model correios_base_calculator.rb to rails 3.2

### DIFF
--- a/app/models/spree/calculator/correios_base_calculator.rb
+++ b/app/models/spree/calculator/correios_base_calculator.rb
@@ -7,6 +7,7 @@ module Spree
     preference :receipt_notification, :boolean, default: false
     preference :receive_in_hands, :boolean, default: false
     
+    attr_accessible :preferred_zipcode, :preferred_token, :preferred_password, :preferred_declared_value, :preferred_receipt_notification, :preferred_receive_in_hands
     attr_reader :delivery_time
     
     def compute(object)


### PR DESCRIPTION
I updated the model <code>correios_base_calculator.rb</code> to Rails 3.2 adding the <code>attr_accessible</code> for the attributies <code>:preferred_zipcode, :preferred_password, :preferred_declared_value, :preferred_receipt_notification, :preferred_receive_in_hands</code>
