### PR TITLE
Ajustes correio

### DIFF
--- a/app/models/spree/calculator/correios_base_calculator.rb
+++ b/app/models/spree/calculator/correios_base_calculator.rb
@@ -23,7 +23,6 @@ module Spree
 
       package = ::Correios::Frete::Pacote.new
       itens.map do |item|
-      order.line_items.map do |item|
         weight = item.product.weight.to_f
         depth  = item.product.depth.to_f
         width  = item.product.width.to_f

--- a/app/models/spree/calculator/pac.rb
+++ b/app/models/spree/calculator/pac.rb
@@ -14,7 +14,7 @@ module Spree
     
     def shipping_code
       if has_contract?
-        41068
+        04669
       else
         04510
       end

--- a/app/models/spree/calculator/pac.rb
+++ b/app/models/spree/calculator/pac.rb
@@ -14,9 +14,9 @@ module Spree
     
     def shipping_code
       if has_contract?
-        04669
+        '04669'
       else
-        04510
+        '04510'
       end
     end
   end

--- a/app/models/spree/calculator/pac.rb
+++ b/app/models/spree/calculator/pac.rb
@@ -16,7 +16,7 @@ module Spree
       if has_contract?
         41068
       else
-        41106
+        04510
       end
     end
   end

--- a/app/models/spree/calculator/sedex.rb
+++ b/app/models/spree/calculator/sedex.rb
@@ -16,7 +16,7 @@ module Spree
       if has_contract?
         40096
       else
-        40010
+        04014
       end
     end
   end

--- a/app/models/spree/calculator/sedex.rb
+++ b/app/models/spree/calculator/sedex.rb
@@ -14,7 +14,7 @@ module Spree
     
     def shipping_code
       if has_contract?
-        40096
+        04162
       else
         04014
       end

--- a/app/models/spree/calculator/sedex.rb
+++ b/app/models/spree/calculator/sedex.rb
@@ -14,9 +14,9 @@ module Spree
     
     def shipping_code
       if has_contract?
-        04162
+        '04162'
       else
-        04014
+        '04014'
       end
     end
   end

--- a/app/models/spree/calculator/sedex10.rb
+++ b/app/models/spree/calculator/sedex10.rb
@@ -9,7 +9,7 @@ module Spree
     end
     
     def shipping_code
-      40215
+      '40215'
     end
   end
 end

--- a/spree_correios.gemspec
+++ b/spree_correios.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_correios'
-  s.version     = '1.0.4'
+  s.version     = '1.0.5'
   s.summary     = %q{A spree extensions to add Brazil's Correio calculators}
   s.required_ruby_version = '>= 1.9.2'
 


### PR DESCRIPTION
Após o dia 05/05/2017, os Correios alteraram os códigos dos serviços PAC e SEDEX. Seguem os novos códigos:

04510 – PAC sem contrato
04669 – PAC com contrato
04014 – SEDEX sem contrato
04162 – SEDEX com contrato